### PR TITLE
fixed flash_class incompatibility with bh so that flash class symbols…

### DIFF
--- a/lib/generators/happy_seed/bootstrap/templates/app/helpers/application_helper.rb
+++ b/lib/generators/happy_seed/bootstrap/templates/app/helpers/application_helper.rb
@@ -1,11 +1,17 @@
 module ApplicationHelper
   def flash_class(level)
     case level.to_sym
-        when :notice then "alert-info"
-        when :success then "alert-success"
-        when :alert then "alert-warning"
-        when :error then "alert-danger"
-        else "alert-danger"
+      # allow either standard rails flash category symbols...
+      when :notice then "info"
+      when :success then "success"
+      when :alert then "warning"
+      when :error then "danger"
+      # ... or bootstrap class symbols
+      when :info then "info"
+      when :warning then "warning"
+      when :danger then "danger"
+      # and default to being alarming
+      else "danger"
     end
   end
 


### PR DESCRIPTION
… work as expected

previously, both happy seed AND bh were attempting to add the "alert-" prefix to the flash symbol we were passing through to bootstrap. 

this made for errors like the one below, where flash[:error] would be correctly interpreted as indicating "alert-danger" by happy seed's application helper, but then bh would fail to find "danger" and fall back on "alert-info" which made my flash warnings look way too happy :)

[31, 40] in /Users/Ben/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/bh-1.3.4/lib/bh/helpers/alert_box_helper.rb
   31:       alert_box = Bh::AlertBox.new(self, *args, &block)
   32:       alert_box.extract! :context, :priority, :dismissible
   33: 
   34:       alert_box.append_class! :alert
   35: byebug # inserted for testing
=> 36:       alert_box.append_class! alert_box.context_class
   37: byebug
   38:       alert_box.merge! role: :alert
   39:       alert_box.prepend_html! alert_box.dismissible_button
   40:       alert_box.render_tag :div
(byebug) args
Session was successfully created and acknowledged by MMB.
{:context=>"alert-danger", :dismissible=>true}
(byebug) alert_box.context_class
alert-info
